### PR TITLE
Pull Request 5/5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Public Server: https://app.remotely.one
 Website: https://remotely.one  
 Subreddit: https://www.reddit.com/r/remotely_app/  
 Docker: https://hub.docker.com/r/translucency/remotely  
+Video Tutorials: https://remotely.one/Tutorials  
 
 ![image](https://user-images.githubusercontent.com/20995508/113913261-f7002a00-9790-11eb-81b3-c36fb8aa536d.png)
 


### PR DESCRIPTION
**Important:** I realize Remotely is currently lacking in unit and integration tests.  I was pretty newb when I wrote a lot of the foundational code, and I haven't had time to refactor and restructure.

I'd like to start changing that, though. Enough people are starting to depend on Remotely that I want to make sure it's maintainable and lives on.  So I need every PR to include automated tests that prove the new functionality is working.

If you have the time and the desire, it would also be incredibly helpful if you included some new tests against services touched by your changes.  I know that this is my mess you're cleaning up, so I thank you wholeheartedly for your help.  The people who use Remotely appreciate it too. :)

*Delete the above and add your PR comments here and delete the above.*


---

Please read the following.  Do not delete below this line.

---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to me (Jared Goodwin) so that I retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that I'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Jared Goodwin, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
